### PR TITLE
Removed localhost link

### DIFF
--- a/content/process_administration.txt
+++ b/content/process_administration.txt
@@ -478,7 +478,7 @@ p engine.process(wfid)
 
 h4(#errors_on_error). on_error
 
-The "@:on_error@ attribute":http://localhost:4331/common_attributes.html#on_error is explained in the "common attributes" page.
+The "@:on_error@ attribute":ruote.rubyforge.org/common_attributes.html#on_error is explained in the "common attributes" page.
 
 (isn't prevention of errors better than dealing with them automatically ?)
 


### PR DESCRIPTION
In the docs apparently a localhost link sneaked in. Replaced it with the ruote.rubyforge.org link.
